### PR TITLE
Synthetic Orderbook Naive Generator

### DIFF
--- a/rust/main.rs
+++ b/rust/main.rs
@@ -1,16 +1,66 @@
-pub mod structs;
 pub mod simulation;
-use crate::simulation::randomizer;
+pub mod structs;
+
+use crate::structs::marketdata::orderbook::Orderbook;
 
 fn main() {
-    
-    // generating Order
-    let i_order = randomizer::randomize_order();
-    println!("{:?}", i_order);
+    let bid_price = 50_000.00;
+    let ask_price = 50_100.00;
+    let tick_size = 100.0;
+    let n_levels = 200;
+    let n_orders = 300;
 
-    // Placeholder for generating Levels<Order>
-    
-    // Placeholder for generating Orderbook<Level>
+    let i_ob = Orderbook::synthetize(bid_price, ask_price, tick_size, n_levels, n_orders);
 
+    println!("\nlevel_id {:?}", i_ob.bids[199].level_id);
+    println!("side {:?}", i_ob.bids[199].side);
+    println!("price {:?}", i_ob.bids[199].price);
+    println!("orders[0]{:?}", i_ob.bids[199].orders[0]);
+    println!("orders[1]{:?}", i_ob.bids[199].orders[1]);
+    println!(" ... ");
+    
+
+    println!("\nlevel_id {:?}", i_ob.bids[0].level_id);
+    println!("side {:?}", i_ob.bids[0].side);
+    println!("price {:?}", i_ob.bids[0].price);
+    println!("orders[0]{:?}", i_ob.bids[0].orders[0]);
+    println!("orders[1]{:?}", i_ob.bids[0].orders[1]);
+    println!(" ... ");
+    
+    let mid_price = (i_ob.bids[0].price + i_ob.asks[0].price) / 2.0;
+    println!("Midprice: {}", mid_price);
+
+    println!("\nlevel_id {:?}", i_ob.asks[0].level_id);
+    println!("side {:?}", i_ob.asks[0].side);
+    println!("price {:?}", i_ob.asks[0].price);
+    println!("orders[0]{:?}", i_ob.asks[0].orders[0]);
+    println!("orders[1]{:?}", i_ob.asks[0].orders[1]);
+    println!(" ... ");
+    
+
+    println!("\nlevel_id {:?}", i_ob.asks[199].level_id);
+    println!("side {:?}", i_ob.asks[199].side);
+    println!("price {:?}", i_ob.asks[199].price);
+    println!("orders[0]{:?}", i_ob.asks[199].orders[0]);
+    println!("orders[1]{:?}", i_ob.asks[199].orders[1]);
+    println!(" ... ");
 }
 
+#[cfg(test)]
+
+mod tests {
+    use crate::Orderbook;
+    
+    #[test]
+    fn symmetric_sides_orderbook() {
+        
+        let bid_price = 50_000.00;
+        let ask_price = 50_100.00;
+        let tick_size = 100.0;
+        let n_levels = 10;
+        let n_orders = 2;
+
+        let i_ob = Orderbook::synthetize(bid_price, ask_price, tick_size, n_levels, n_orders);
+        assert_eq!(i_ob.asks.len(), i_ob.bids.len());
+    }
+}

--- a/rust/simulation/randomizer.rs
+++ b/rust/simulation/randomizer.rs
@@ -1,29 +1,34 @@
-
-use rand::Rng;
-use::std::time::{Instant, Duration};
 use crate::structs::marketdata::order::Order;
+use rand::distributions::Uniform;
+use rand::Rng;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 // Create a random Order according to the provided parameters
-// it uses structs::marketdata::order::Order 
+// it uses structs::marketdata::order::Order
 
-pub fn randomize_order() -> Order {
-    
+pub fn randomize_order(side: String, price: f64) -> Order {
     let mut uni_rand = rand::thread_rng();
-    
+
     // Randomize order_ts
-    let now_ts: f64 = Instant::now().elapsed().as_millis() as f64;
-    let ms_offset: Duration  = Duration::from_millis(uni_rand.gen::<u64>() as u64);
-    let order_ts: f64 = now_ts + (ms_offset.as_millis() as f64) / 1e9;
+    let now_ts = SystemTime::now();
+    // println!("now_ts: {:?}", now_ts);
 
-    // Randomize price
-    let price = (uni_rand.gen::<f64>() * 10.0) + 1.0;
-    
+    let since_epoch_ts = now_ts
+        .duration_since(UNIX_EPOCH)
+        .expect("Time went backwards")
+        .as_millis();
+    // println!("since_epoch_ts: {:?}", since_epoch_ts);
+
+    // Random millis between orders ~Uniform(1,30)
+    let ms_offset = uni_rand.sample(Uniform::new(1, 30));
+    // println!("ms_offset: {:?}", ms_offset);
+
+    let order_ts = since_epoch_ts as u64 + ms_offset;
+    // println!("order_ts: {}", order_ts);
+
     // Randomize amount
-    let amount = (uni_rand.gen::<f64>() * 100.0) + 1.0;
+    let amount = uni_rand.sample(Uniform::new(0.01, 10.0));
 
-    // Randomize side
-    let side = if uni_rand.gen::<f64>() < 0.5 { true } else { false };
-    
     // Randomize order_id
     let order_id: u32 = 123;
 
@@ -32,8 +37,6 @@ pub fn randomize_order() -> Order {
         order_ts,
         side,
         price,
-        amount
+        amount,
     }
-
 }
-

--- a/rust/structs/marketdata/level.rs
+++ b/rust/structs/marketdata/level.rs
@@ -1,23 +1,20 @@
-
 use crate::structs::marketdata::order::Order;
 
+#[derive(Debug)]
 pub struct Level {
     pub level_id: u32,
-    pub side: bool,
+    pub side: String,
     pub price: f64,
     pub orders: Vec<Order>,
 }
 
 impl Level {
-
-   pub fn new(level_id:u32, side:bool, price:f64, orders:Vec<Order>) -> Self {
-    Level {
+    pub fn new(level_id: u32, side: String, price: f64, orders: Vec<Order>) -> Self {
+        Level {
             level_id,
             side,
             price,
             orders,
         }
-    } 
-
+    }
 }
-

--- a/rust/structs/marketdata/mod.rs
+++ b/rust/structs/marketdata/mod.rs
@@ -1,3 +1,3 @@
-pub mod orderbook;
 pub mod level;
 pub mod order;
+pub mod orderbook;

--- a/rust/structs/marketdata/order.rs
+++ b/rust/structs/marketdata/order.rs
@@ -1,17 +1,14 @@
-
 #[derive(Debug)]
 pub struct Order {
-    
     pub order_id: u32,
-    pub order_ts: f64,
-    pub side: bool,
+    pub order_ts: u64,
+    pub side: String,
     pub price: f64,
     pub amount: f64,
 }
 
 impl Order {
-
-    pub fn new(order_id: u32, order_ts:f64, side: bool, price:f64, amount:f64) -> Self {
+    pub fn new(order_id: u32, order_ts: u64, side: String, price: f64, amount: f64) -> Self {
         Order {
             order_id,
             order_ts,
@@ -20,5 +17,4 @@ impl Order {
             amount,
         }
     }
-
 }

--- a/rust/structs/marketdata/orderbook.rs
+++ b/rust/structs/marketdata/orderbook.rs
@@ -1,7 +1,10 @@
+use crate::{
+    simulation::randomizer::randomize_order, structs::marketdata::level::Level,
+    structs::marketdata::order::Order,
+};
 
-use crate::structs::marketdata::level::Level;
-
-pub struct Orderbook{
+#[derive(Debug)]
+pub struct Orderbook {
     pub orderbook_id: u32,
     pub orderbook_ts: f64,
     pub symbol: String,
@@ -9,14 +12,73 @@ pub struct Orderbook{
     pub asks: Vec<Level>,
 }
 
-impl Orderbook{
-    pub fn new(orderbook_id: u32, orderbook_ts: f64, symbol: String, bids: Vec<Level>, asks: Vec<Level>) -> Self {
+impl Orderbook {
+    pub fn new(
+        orderbook_id: u32,
+        orderbook_ts: f64,
+        symbol: String,
+        bids: Vec<Level>,
+        asks: Vec<Level>,
+    ) -> Self {
         Orderbook {
             orderbook_id,
             orderbook_ts,
             symbol,
             bids,
             asks,
+        }
+    }
+
+    pub fn synthetize(
+        bid_price: f64,
+        ask_price: f64,
+        tick_size: f64,
+        n_levels: u32,
+        n_orders: u32,
+    ) -> Self {
+        let mut i_bids = Vec::new();
+        let mut i_asks = Vec::new();
+
+        for i in 1..=n_levels {
+            let i_bid_price = bid_price - (&tick_size * i as f64);
+            let i_bid_side = "BUY";
+
+            let mut v_bid_orders: Vec<Order> = (0..n_orders)
+                .map(|_| randomize_order(i_bid_side.to_string(), i_bid_price))
+                .collect();
+
+            v_bid_orders.sort_by_key(|order| order.order_ts);
+
+            i_bids.push(Level {
+                level_id: i,
+                side: i_bid_side.to_string(),
+                price: i_bid_price,
+                orders: v_bid_orders,
+            });
+
+            let i_ask_price = ask_price + (&tick_size * i as f64);
+            let i_ask_side = "SELL";
+
+            let mut v_ask_orders: Vec<Order> = (0..n_orders)
+                .map(|_| randomize_order(i_ask_side.to_string(), i_ask_price))
+                .collect();
+
+            v_ask_orders.sort_by_key(|order| order.order_ts);
+
+            i_asks.push(Level {
+                level_id: i,
+                side: i_ask_side.to_string(),
+                price: i_ask_price,
+                orders: v_ask_orders,
+            });
+        }
+
+        Orderbook {
+            orderbook_id: 123,
+            orderbook_ts: 321.0,
+            symbol: String::from("BTCUSDT"),
+            bids: i_bids,
+            asks: i_asks,
         }
     }
 }


### PR DESCRIPTION

A synthetic orderbook creation is a process that generates from purely random, or non-regressive way, the necessary data for an Orderbook to exist. That is, sides, levels and orders with price, volume and timestamp. 

basic usage is:

```rust
fn main() {
  
  let bid_price = 50_000.00;
  let ask_price = 50_100.00;
  let tick_size = 100.0;
  let n_levels = 200;
  let n_orders = 300;
  
  let i_ob = Orderbook::synthetize(bid_price, ask_price, tick_size, n_levels, n_orders);
  
  println!("\nlevel_id {:?}", i_ob.bids[199].level_id);
  println!("side {:?}", i_ob.bids[199].side);
  println!("price {:?}", i_ob.bids[199].price);
  println!("orders[0]{:?}", i_ob.bids[199].orders[0]);
  println!("orders[1]{:?}", i_ob.bids[199].orders[1]);
}
```

And modified files where mainly the following: 

- the ones in the mod structs/marketdata/