### PR TITLE
Generalize data insertion capacity in orderbook

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -30,10 +30,6 @@ jobs:
           - nightly
     steps:
       - uses: actions/checkout@v4
-      - name: Install protoc
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y protobuf-compiler
       - uses: Swatinem/rust-cache@v2
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - run: cargo check 

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -30,6 +30,10 @@ jobs:
           - nightly
     steps:
       - uses: actions/checkout@v4
+      - name: Install protoc
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
       - uses: Swatinem/rust-cache@v2
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - run: cargo check 

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -1,9 +1,9 @@
-on: 
-  pull_request
-
-name: 
-  Rust
-
+name: Rust
+permissions:
+  pull-requests: read
+  statuses: write
+on:
+  pull_request:
 env: 
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -D warnings

--- a/atelier/Cargo.toml
+++ b/atelier/Cargo.toml
@@ -14,8 +14,7 @@ serde = { version = "1.0.203", features = ["derive"] }
 
 rand = {version="0.8.5"}
 rand_distr = "0.4.3"
-
-[dev-dependencies]
+trolly = { version = "*", git = "https://github.com/CAGS295/trolly.git" }
 
 [lib]
 name = "atelier"

--- a/atelier/Cargo.toml
+++ b/atelier/Cargo.toml
@@ -14,7 +14,7 @@ serde = { version = "1.0.203", features = ["derive"] }
 
 rand = {version="0.8.5"}
 rand_distr = "0.4.3"
-trolly = { version = "*", git = "https://github.com/CAGS295/trolly.git" }
+trolly = { version = "*", git = "https://github.com/CAGS295/trolly.git" , default-features = false }
 
 [lib]
 name = "atelier"

--- a/atelier/examples/ob_gen_naive.rs
+++ b/atelier/examples/ob_gen_naive.rs
@@ -10,14 +10,12 @@ fn main() {
     let i_ob = Orderbook::synthetize(bid_price, ask_price, tick_size, n_levels, n_orders);
 
     println!("\nlevel_id {:?}", i_ob.bids[199].level_id);
-    println!("side {:?}", i_ob.bids[199].side);
     println!("price {:?}", i_ob.bids[199].price);
     println!("orders[0]{:?}", i_ob.bids[199].orders[0]);
     println!("orders[1]{:?}", i_ob.bids[199].orders[1]);
     println!(" ... ");
 
     println!("\nlevel_id {:?}", i_ob.bids[0].level_id);
-    println!("side {:?}", i_ob.bids[0].side);
     println!("price {:?}", i_ob.bids[0].price);
     println!("orders[0]{:?}", i_ob.bids[0].orders[0]);
     println!("orders[1]{:?}", i_ob.bids[0].orders[1]);
@@ -27,14 +25,12 @@ fn main() {
     println!("Midprice: {}", mid_price);
 
     println!("\nlevel_id {:?}", i_ob.asks[0].level_id);
-    println!("side {:?}", i_ob.asks[0].side);
     println!("price {:?}", i_ob.asks[0].price);
     println!("orders[0]{:?}", i_ob.asks[0].orders[0]);
     println!("orders[1]{:?}", i_ob.asks[0].orders[1]);
     println!(" ... ");
 
     println!("\nlevel_id {:?}", i_ob.asks[199].level_id);
-    println!("side {:?}", i_ob.asks[199].side);
     println!("price {:?}", i_ob.asks[199].price);
     println!("orders[0]{:?}", i_ob.asks[199].orders[0]);
     println!("orders[1]{:?}", i_ob.asks[199].orders[1]);

--- a/atelier/examples/ob_gen_naive.rs
+++ b/atelier/examples/ob_gen_naive.rs
@@ -7,32 +7,32 @@ fn main() {
     let n_levels = 200;
     let n_orders = 300;
 
-    let i_ob = Orderbook::synthetize(bid_price, ask_price, tick_size, n_levels, n_orders);
+    let ob = Orderbook::synthetize(bid_price, ask_price, tick_size, n_levels, n_orders);
 
-    println!("\nlevel_id {:?}", i_ob.bids[199].level_id);
-    println!("price {:?}", i_ob.bids[199].price);
-    println!("orders[0]{:?}", i_ob.bids[199].orders[0]);
-    println!("orders[1]{:?}", i_ob.bids[199].orders[1]);
+    println!("\nlevel_id {:?}", ob.bids[199].level_id);
+    println!("price {:?}", ob.bids[199].price);
+    println!("orders[0]{:?}", ob.bids[199].orders[0]);
+    println!("orders[1]{:?}", ob.bids[199].orders[1]);
     println!(" ... ");
 
-    println!("\nlevel_id {:?}", i_ob.bids[0].level_id);
-    println!("price {:?}", i_ob.bids[0].price);
-    println!("orders[0]{:?}", i_ob.bids[0].orders[0]);
-    println!("orders[1]{:?}", i_ob.bids[0].orders[1]);
+    println!("\nlevel_id {:?}", ob.bids[0].level_id);
+    println!("price {:?}", ob.bids[0].price);
+    println!("orders[0]{:?}", ob.bids[0].orders[0]);
+    println!("orders[1]{:?}", ob.bids[0].orders[1]);
     println!(" ... ");
 
-    let mid_price = (i_ob.bids[0].price + i_ob.asks[0].price) / 2.0;
+    let mid_price = (ob.bids[0].price + ob.asks[0].price) / 2.0;
     println!("Midprice: {}", mid_price);
 
-    println!("\nlevel_id {:?}", i_ob.asks[0].level_id);
-    println!("price {:?}", i_ob.asks[0].price);
-    println!("orders[0]{:?}", i_ob.asks[0].orders[0]);
-    println!("orders[1]{:?}", i_ob.asks[0].orders[1]);
+    println!("\nlevel_id {:?}", ob.asks[0].level_id);
+    println!("price {:?}", ob.asks[0].price);
+    println!("orders[0]{:?}", ob.asks[0].orders[0]);
+    println!("orders[1]{:?}", ob.asks[0].orders[1]);
     println!(" ... ");
 
-    println!("\nlevel_id {:?}", i_ob.asks[199].level_id);
-    println!("price {:?}", i_ob.asks[199].price);
-    println!("orders[0]{:?}", i_ob.asks[199].orders[0]);
-    println!("orders[1]{:?}", i_ob.asks[199].orders[1]);
+    println!("\nlevel_id {:?}", ob.asks[199].level_id);
+    println!("price {:?}", ob.asks[199].price);
+    println!("orders[0]{:?}", ob.asks[199].orders[0]);
+    println!("orders[1]{:?}", ob.asks[199].orders[1]);
     println!(" ... ");
 }

--- a/atelier/examples/ob_metrics.rs
+++ b/atelier/examples/ob_metrics.rs
@@ -25,23 +25,15 @@ fn main() {
     println!("Midprice: {}", midprice_value);
 
     // Compute the Volume Imbalance
-    let iter_bids: Vec<f64> = i_ob.bids.clone().into_iter().map(|x| x.volume).collect();
-    let iter_asks: Vec<f64> = i_ob.asks.clone().into_iter().map(|x| x.volume).collect();
+    let iter_bids: Vec<f64> = i_ob.bids.iter().map(|x| x.volume).collect();
+    let iter_asks: Vec<f64> = i_ob.asks.iter().map(|x| x.volume).collect();
 
     let obimb_value = VolumeImbalance::compute(&iter_bids, &iter_asks, 1);
     println!("Volume Imbalance: {:?}", obimb_value);
 
     // Compute the Volume-Weighted Average Price
-    let iter_bids: Vec<_> = i_ob
-        .bids
-        .into_iter()
-        .map(|x| vec![x.price, x.volume])
-        .collect();
-    let iter_asks: Vec<_> = i_ob
-        .asks
-        .into_iter()
-        .map(|x| vec![x.price, x.volume])
-        .collect();
+    let iter_bids: Vec<_> = i_ob.bids.iter().map(|x| vec![x.price, x.volume]).collect();
+    let iter_asks: Vec<_> = i_ob.asks.iter().map(|x| vec![x.price, x.volume]).collect();
 
     // Compute the VWAP
     let vwap_value = VWAP::compute(&iter_bids.clone(), &iter_asks.clone(), 1);

--- a/atelier/src/data/market.rs
+++ b/atelier/src/data/market.rs
@@ -1,4 +1,7 @@
+use std::ops::Deref;
+
 use crate::simulation::randomizer::randomize_order;
+use trolly::lob::ops::PartitionPredicate;
 
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd)]
 pub enum Side {
@@ -122,8 +125,21 @@ impl Level {
     }
 }
 
+// This is how the updater knows the Ordering of the Bids
+impl PartitionPredicate for Bids {
+    fn partition_predicate<P: PartialOrd>(lhs: &P, rhs: &P) -> bool {
+        lhs > rhs
+    }
+}
+
+// This is how the updater knows the Ordering of the Asks
+impl PartitionPredicate for Asks {
+    fn partition_predicate<P: PartialOrd>(lhs: &P, rhs: &P) -> bool {
+        lhs < rhs
+    }
+}
+
 // ------------------------------------------------------------ ORDERBOOK -- //
-// ------------------------------------------------------------------------- //
 
 /// Represents a Limit Order Book for a specific market.
 ///
@@ -137,9 +153,14 @@ pub struct Orderbook {
     pub orderbook_id: u32,
     pub orderbook_ts: u64,
     pub symbol: String,
-    pub bids: Vec<Level>,
-    pub asks: Vec<Level>,
+    pub bids: Bids,
+    pub asks: Asks,
 }
+
+#[derive(Debug, Clone, PartialEq, PartialOrd)]
+pub struct Bids(pub Vec<Level>);
+#[derive(Debug, Clone, PartialEq, PartialOrd)]
+pub struct Asks(pub Vec<Level>);
 
 impl Orderbook {
     // ---------------------------------------------------- New Orderbook -- //
@@ -162,8 +183,8 @@ impl Orderbook {
         orderbook_id: u32,
         orderbook_ts: u64,
         symbol: String,
-        bids: Vec<Level>,
-        asks: Vec<Level>,
+        bids: Bids,
+        asks: Asks,
     ) -> Self {
         Orderbook {
             orderbook_id,
@@ -245,9 +266,25 @@ impl Orderbook {
             orderbook_id: 123,
             orderbook_ts: 321,
             symbol: String::from("BTCUSDT"),
-            bids: i_bids,
-            asks: i_asks,
+            bids: Bids(i_bids),
+            asks: Asks(i_asks),
         }
+    }
+}
+
+impl Deref for Bids {
+    type Target = Vec<Level>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Deref for Asks {
+    type Target = Vec<Level>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 
@@ -288,7 +325,13 @@ pub mod test {
             orders: vec![],
         }];
 
-        let i_ob = Orderbook::new(123, 123, String::from("BTCUSDT"), bid_level, ask_level);
+        let i_ob = Orderbook::new(
+            123,
+            123,
+            String::from("BTCUSDT"),
+            Bids(bid_level),
+            Asks(ask_level),
+        );
 
         println!("pre-bid_price {}", i_ob.bids[0].price);
         println!("pre-ask_price {}", i_ob.asks[0].price);

--- a/atelier/src/data/market.rs
+++ b/atelier/src/data/market.rs
@@ -271,3 +271,128 @@ impl Orderbook {
         }
     }
 }
+
+#[cfg(test)]
+pub mod test {
+    use crate::simulation::randomizer;
+
+    use super::*;
+
+    #[test]
+    fn symmetric_sides() {
+        let bid_price = 50_000.00;
+        let ask_price = 50_100.00;
+        let tick_size = 100.0;
+        let n_levels = 10;
+        let n_orders = 2;
+
+        let i_ob = Orderbook::synthetize(
+            bid_price, ask_price, tick_size, n_levels, n_orders,
+        );
+
+        assert_eq!(i_ob.bids.len(), n_levels as usize);
+        assert_eq!(i_ob.asks.len(), n_levels as usize);
+        assert_eq!(i_ob.bids.len(), i_ob.asks.len());
+    }
+
+    #[test]
+    fn orderbook_insert_levels() {
+        let bid_level = vec![Level {
+            level_id: 1,
+            side: Side::Bids,
+            price: 60_000.00,
+            volume: 1.0,
+            orders: None,
+        }];
+
+        let ask_level = vec![Level {
+            level_id: 1,
+            side: Side::Asks,
+            price: 60_001.00,
+            volume: 1.1,
+            orders: None,
+        }];
+
+        let i_ob = Orderbook::new(
+            123,
+            123,
+            String::from("BTCUSDT"),
+            bid_level,
+            ask_level,
+        );
+
+        println!("pre-bid_price {}", i_ob.bids[0].price);
+        println!("pre-ask_price {}", i_ob.asks[0].price);
+    }
+
+    #[test]
+    fn naive_progression() {
+        // A correct progression of an orderbook should produce:
+        // different orders at the same side -> level -> order queue
+
+        // Parameters for the orderbook creation
+        let bid_price = 50_000.00;
+        let ask_price = 50_100.00;
+        let tick_size = 50.0;
+        let n_levels = 20;
+        let n_orders = 5;
+
+        // Parameters for the midprice progression model
+        let mu = 0.0001;
+        let sigma = 0.0025;
+
+        let orderbook = Orderbook::synthetize(
+            bid_price, ask_price, tick_size, n_levels, n_orders,
+        );
+        let mut n_orderbooks: Vec<Orderbook> = vec![];
+        n_orderbooks.push(orderbook);
+
+        for i in 0..=3 {
+            let i_bid_price = n_orderbooks[i].bids[0].price;
+            let i_ret_gbm_bids: f64 =
+                randomizer::gbm_return(i_bid_price, mu, sigma, 1.0);
+
+            let i_ask_price = n_orderbooks[i].asks[0].price;
+            let i_ret_gbm_asks: f64 =
+                randomizer::gbm_return(i_ask_price, mu, sigma, 1.0);
+
+            let i_orderbook = Orderbook::synthetize(
+                i_bid_price - i_ret_gbm_bids,
+                i_ask_price + i_ret_gbm_asks,
+                tick_size,
+                n_levels,
+                n_orders,
+            );
+
+            n_orderbooks.push(i_orderbook);
+        }
+
+        // for the first and second orderbook, compare the first order of the first level
+
+        // for the bid side
+        let t0_bids0_order0 = n_orderbooks[0].bids[0]
+            .orders
+            .as_ref()
+            .map(|o| o[0])
+            .unwrap();
+        let t1_bids0_order0 = n_orderbooks[1].bids[0]
+            .orders
+            .as_ref()
+            .map(|o| o[0])
+            .unwrap();
+        assert_ne!(t0_bids0_order0, t1_bids0_order0);
+
+        // for ask side
+        let t0_asks0_order0 = n_orderbooks[0].asks[0]
+            .orders
+            .as_ref()
+            .map(|o| o[0])
+            .unwrap();
+        let t1_asks0_order0 = n_orderbooks[1].asks[0]
+            .orders
+            .as_ref()
+            .map(|o| o[0])
+            .unwrap();
+        assert_ne!(t0_asks0_order0, t1_asks0_order0);
+    }
+}

--- a/atelier/src/data/market.rs
+++ b/atelier/src/data/market.rs
@@ -93,7 +93,6 @@ impl Order {
 #[derive(Debug, Clone, PartialEq, PartialOrd)]
 pub struct Level {
     pub level_id: u32,
-    pub side: Side,
     pub price: f64,
     pub volume: f64,
     pub orders: Vec<Order>,
@@ -113,27 +112,9 @@ impl Level {
     /// # Returns
     ///
     /// Returns a new `Level` instance with the specified parameters.
-    pub fn new(level_id: u32, side: Side, price: f64, volume: f64, orders: Vec<Order>) -> Self {
-        match side {
-            Side::Bids => Level {
-                level_id,
-                side: Side::Bids,
-                price,
-                volume,
-                orders: orders.clone(),
-            },
-            Side::Asks => Level {
-                level_id,
-                side: Side::Asks,
-                price,
-                volume,
-                orders: orders.clone(),
-            },
-        };
-
+    pub fn new(level_id: u32, price: f64, volume: f64, orders: Vec<Order>) -> Self {
         Level {
             level_id,
-            side,
             price,
             volume,
             orders,
@@ -236,7 +217,6 @@ impl Orderbook {
 
             i_bids.push(Level {
                 level_id: i,
-                side: i_bid_side,
                 price: i_bid_price,
                 volume: i_bid_volume,
                 orders: v_bid_orders,
@@ -255,7 +235,6 @@ impl Orderbook {
 
             i_asks.push(Level {
                 level_id: i,
-                side: i_ask_side,
                 price: i_ask_price,
                 volume: i_ask_volume,
                 orders: v_ask_orders,
@@ -286,9 +265,7 @@ pub mod test {
         let n_levels = 10;
         let n_orders = 2;
 
-        let i_ob = Orderbook::synthetize(
-            bid_price, ask_price, tick_size, n_levels, n_orders,
-        );
+        let i_ob = Orderbook::synthetize(bid_price, ask_price, tick_size, n_levels, n_orders);
 
         assert_eq!(i_ob.bids.len(), n_levels as usize);
         assert_eq!(i_ob.asks.len(), n_levels as usize);
@@ -299,27 +276,19 @@ pub mod test {
     fn orderbook_insert_levels() {
         let bid_level = vec![Level {
             level_id: 1,
-            side: Side::Bids,
             price: 60_000.00,
             volume: 1.0,
-            orders: None,
+            orders: vec![],
         }];
 
         let ask_level = vec![Level {
             level_id: 1,
-            side: Side::Asks,
             price: 60_001.00,
             volume: 1.1,
-            orders: None,
+            orders: vec![],
         }];
 
-        let i_ob = Orderbook::new(
-            123,
-            123,
-            String::from("BTCUSDT"),
-            bid_level,
-            ask_level,
-        );
+        let i_ob = Orderbook::new(123, 123, String::from("BTCUSDT"), bid_level, ask_level);
 
         println!("pre-bid_price {}", i_ob.bids[0].price);
         println!("pre-ask_price {}", i_ob.asks[0].price);
@@ -341,20 +310,16 @@ pub mod test {
         let mu = 0.0001;
         let sigma = 0.0025;
 
-        let orderbook = Orderbook::synthetize(
-            bid_price, ask_price, tick_size, n_levels, n_orders,
-        );
+        let orderbook = Orderbook::synthetize(bid_price, ask_price, tick_size, n_levels, n_orders);
         let mut n_orderbooks: Vec<Orderbook> = vec![];
         n_orderbooks.push(orderbook);
 
         for i in 0..=3 {
             let i_bid_price = n_orderbooks[i].bids[0].price;
-            let i_ret_gbm_bids: f64 =
-                randomizer::gbm_return(i_bid_price, mu, sigma, 1.0);
+            let i_ret_gbm_bids: f64 = randomizer::gbm_return(i_bid_price, mu, sigma, 1.0);
 
             let i_ask_price = n_orderbooks[i].asks[0].price;
-            let i_ret_gbm_asks: f64 =
-                randomizer::gbm_return(i_ask_price, mu, sigma, 1.0);
+            let i_ret_gbm_asks: f64 = randomizer::gbm_return(i_ask_price, mu, sigma, 1.0);
 
             let i_orderbook = Orderbook::synthetize(
                 i_bid_price - i_ret_gbm_bids,
@@ -370,29 +335,13 @@ pub mod test {
         // for the first and second orderbook, compare the first order of the first level
 
         // for the bid side
-        let t0_bids0_order0 = n_orderbooks[0].bids[0]
-            .orders
-            .as_ref()
-            .map(|o| o[0])
-            .unwrap();
-        let t1_bids0_order0 = n_orderbooks[1].bids[0]
-            .orders
-            .as_ref()
-            .map(|o| o[0])
-            .unwrap();
+        let t0_bids0_order0 = n_orderbooks[0].bids[0].orders.first().unwrap();
+        let t1_bids0_order0 = n_orderbooks[1].bids[0].orders.first().unwrap();
         assert_ne!(t0_bids0_order0, t1_bids0_order0);
 
         // for ask side
-        let t0_asks0_order0 = n_orderbooks[0].asks[0]
-            .orders
-            .as_ref()
-            .map(|o| o[0])
-            .unwrap();
-        let t1_asks0_order0 = n_orderbooks[1].asks[0]
-            .orders
-            .as_ref()
-            .map(|o| o[0])
-            .unwrap();
+        let t0_asks0_order0 = n_orderbooks[0].asks[0].orders.first().unwrap();
+        let t1_asks0_order0 = n_orderbooks[1].asks[0].orders.first().unwrap();
         assert_ne!(t0_asks0_order0, t1_asks0_order0);
     }
 }

--- a/atelier/src/data/market.rs
+++ b/atelier/src/data/market.rs
@@ -1,7 +1,10 @@
-use std::ops::Deref;
+use std::ops::{Deref, DerefMut};
 
 use crate::simulation::randomizer::randomize_order;
-use trolly::lob::ops::PartitionPredicate;
+use trolly::lob::{
+    ops::{update_strategies::ReplaceOrRemove, PartitionPredicate, Update},
+    price_and_quantity::{Price, Quantity},
+};
 
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd)]
 pub enum Side {
@@ -128,14 +131,80 @@ impl Level {
 // This is how the updater knows the Ordering of the Bids
 impl PartitionPredicate for Bids {
     fn partition_predicate<P: PartialOrd>(lhs: &P, rhs: &P) -> bool {
-        lhs > rhs
+        lhs < rhs
     }
 }
 
 // This is how the updater knows the Ordering of the Asks
 impl PartitionPredicate for Asks {
     fn partition_predicate<P: PartialOrd>(lhs: &P, rhs: &P) -> bool {
-        lhs < rhs
+        lhs > rhs
+    }
+}
+
+impl Update<ReplaceOrRemove> for Bids {
+    type Level = Level;
+    type Key = usize;
+
+    fn entry(&mut self, level_update: &Self::Level) -> (Self::Key, Option<&Self::Level>)
+    where
+        <Self::Level as trolly::lob::price_and_quantity::Price>::P: PartialOrd,
+    {
+        let index = self.partition_point(|value| {
+            Self::partition_predicate(Price::to_ref(value), Price::to_ref(level_update))
+        });
+        (index, self.get(index))
+    }
+
+    fn digest_operation(
+        &mut self,
+        operator: ReplaceOrRemove,
+        key: &Self::Key,
+        level_update: Self::Level,
+    ) {
+        match operator {
+            ReplaceOrRemove::Replace => {
+                self[*key] = level_update;
+            }
+            ReplaceOrRemove::Remove => {
+                self.remove(*key);
+            }
+            ReplaceOrRemove::Displace => self.insert(*key, level_update),
+            ReplaceOrRemove::Noop => {}
+        }
+    }
+}
+
+impl Update<ReplaceOrRemove> for Asks {
+    type Level = Level;
+    type Key = usize;
+
+    fn entry(&mut self, level_update: &Self::Level) -> (Self::Key, Option<&Self::Level>)
+    where
+        <Self::Level as trolly::lob::price_and_quantity::Price>::P: PartialOrd,
+    {
+        let index = self.partition_point(|value| {
+            Self::partition_predicate(Price::to_ref(value), Price::to_ref(level_update))
+        });
+        (index, self.get(index))
+    }
+
+    fn digest_operation(
+        &mut self,
+        operator: ReplaceOrRemove,
+        key: &Self::Key,
+        level_update: Self::Level,
+    ) {
+        match operator {
+            ReplaceOrRemove::Replace => {
+                self[*key] = level_update;
+            }
+            ReplaceOrRemove::Remove => {
+                self.remove(*key);
+            }
+            ReplaceOrRemove::Displace => self.insert(*key, level_update),
+            ReplaceOrRemove::Noop => {}
+        }
     }
 }
 
@@ -193,6 +262,16 @@ impl Orderbook {
             bids,
             asks,
         }
+    }
+
+    pub fn insert_bid(&mut self, level: Level) {
+        // If an old level is found, replace it; if the Level is not found, insert the new one.
+        Update::<ReplaceOrRemove>::process(&mut self.bids, level);
+    }
+
+    pub fn insert_ask(&mut self, level: Level) {
+        // If an old level is found, replace it; if the Level is not found, insert the new one.
+        Update::<ReplaceOrRemove>::process(&mut self.asks, level);
     }
 
     // ---------------------------------------------- Synthetic Orderbook -- //
@@ -280,11 +359,51 @@ impl Deref for Bids {
     }
 }
 
+impl DerefMut for Bids {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
 impl Deref for Asks {
     type Target = Vec<Level>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl DerefMut for Asks {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl Quantity for Level {
+    type Q = f64;
+
+    fn to_ref(&self) -> &Self::Q {
+        &self.volume
+    }
+}
+
+impl Price for Level {
+    type P = f64;
+
+    fn to_ref(&self) -> &Self::P {
+        &self.price
+    }
+}
+
+impl Bids {
+    pub fn new() -> Self {
+        Self(vec![])
+    }
+}
+
+impl Asks {
+    pub fn new() -> Self {
+        Self(vec![])
     }
 }
 
@@ -386,5 +505,51 @@ pub mod test {
         let t0_asks0_order0 = n_orderbooks[0].asks[0].orders.first().unwrap();
         let t1_asks0_order0 = n_orderbooks[1].asks[0].orders.first().unwrap();
         assert_ne!(t0_asks0_order0, t1_asks0_order0);
+    }
+
+    #[test]
+    fn insert_bid_works() {
+        let mut ob = Orderbook::new(0, 0, String::from("btc"), Bids::new(), Asks::new());
+        let level = Level::new(0, 1., 1., vec![]);
+        ob.insert_bid(level);
+        assert_eq!(ob.bids.0, [Level::new(0, 1., 1., vec![])]);
+        let level = Level::new(0, 0., 1., vec![]);
+        ob.insert_bid(level);
+        assert_eq!(
+            ob.bids.0,
+            [Level::new(0, 0., 1., vec![]), Level::new(0, 1., 1., vec![])]
+        );
+        let level = Level::new(0, 1., 2., vec![]);
+        ob.insert_bid(level);
+        assert_eq!(
+            ob.bids.0,
+            [Level::new(0, 0., 1., vec![]), Level::new(0, 1., 2., vec![])]
+        );
+        let level = Level::new(0, 1., 0., vec![]);
+        ob.insert_bid(level);
+        assert_eq!(ob.bids.0, [Level::new(0, 0., 1., vec![])]);
+    }
+
+    #[test]
+    fn insert_ask_works() {
+        let mut ob = Orderbook::new(0, 0, String::from("btc"), Bids::new(), Asks::new());
+        let level = Level::new(0, 1., 1., vec![]);
+        ob.insert_ask(level);
+        assert_eq!(ob.asks.0, [Level::new(0, 1., 1., vec![])]);
+        let level = Level::new(0, 0., 1., vec![]);
+        ob.insert_ask(level);
+        assert_eq!(
+            ob.asks.0,
+            [Level::new(0, 1., 1., vec![]), Level::new(0, 0., 1., vec![])]
+        );
+        let level = Level::new(0, 1., 2., vec![]);
+        ob.insert_ask(level);
+        assert_eq!(
+            ob.asks.0,
+            [Level::new(0, 1., 2., vec![]), Level::new(0, 0., 1., vec![])]
+        );
+        let level = Level::new(0, 1., 0., vec![]);
+        ob.insert_ask(level);
+        assert_eq!(ob.asks.0, [Level::new(0, 0., 1., vec![])]);
     }
 }

--- a/atelier/src/simulation/randomizer.rs
+++ b/atelier/src/simulation/randomizer.rs
@@ -50,6 +50,6 @@ pub fn gbm_return(s0: f64, mu: f64, sigma: f64, t: f64) -> f64 {
     let dwt = generators::pdf_standard_normal();
     let drift = mu * s0 * t;
     let diffusion = sigma * s0 * dwt;
-    let dst = drift + diffusion;
-    dst
+    
+    drift + diffusion
 }

--- a/atelier/src/simulation/randomizer.rs
+++ b/atelier/src/simulation/randomizer.rs
@@ -50,6 +50,6 @@ pub fn gbm_return(s0: f64, mu: f64, sigma: f64, t: f64) -> f64 {
     let dwt = generators::pdf_standard_normal();
     let drift = mu * s0 * t;
     let diffusion = sigma * s0 * dwt;
-    
+
     drift + diffusion
 }


### PR DESCRIPTION
quick fix to extend the functionality of the Orderbook struct:

1. Added a `volume` field in the `Level` type which is used in the bids: `Vec<Level>`, `asks: Vec<Level>` within the `Orderbook` type. With this, now there is the optionality of either providing order-level granularity, or, just price and volume granularity, when creating a Level. And so to keep supporting the two types of filling processes:

- For the Synthetic Data Generation: The `volume` field in the `Level` type, now is the sum of the generated vector of `Order` types. 
- For the Market Data Insertion: The `volume` field is one field within the `Level` type that is needed to be included.

2. Created the `insert` method for the `Orderbook` type.

Insertion into the `Orderbook` corresponding fields `bids` and `asks` now can be done by providing a collection of `Level`-like compatible types, including an internal validation of this. 

For this PR only one case is implemented, a struct with named and typed fields that mimic 1:1 of those of the `Level` internal type at `atelier::data::market::Level` 

3. Introduced some formatting changes.

In this PR there are changes given a few slight modifications on the rust formatting options within the added file `rustfmt.toml`.

4. Tests file modification.

For better separation of concerns, the corresponding tests will be placed at `tests/orderbook_static.rs`, under the `fn orderbook_insert_levels()`