### PR TITLE
Minimal Custom Error Types

### DIFF
--- a/atelier/Cargo.toml
+++ b/atelier/Cargo.toml
@@ -14,7 +14,7 @@ include = ["src/**/*", "katex-header.html"]
 
 [dependencies]
 serde = { version = "1.0.203", features = ["derive"] }
-
+thiserror = { version = "1.0.64" }
 rand = {version="0.8.5"}
 rand_distr = "0.4.3"
 

--- a/atelier/src/errors/errors.rs
+++ b/atelier/src/errors/errors.rs
@@ -1,0 +1,66 @@
+//! Custom Error Types 
+//! Provides the definition of error types that are custom made for the atelier project.
+
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum LevelError {
+
+    // Level not found
+    #[error("Level not found")]
+    LevelNotFound,
+
+    // Level info not available
+    #[error("Level info not available")]
+    LevelInfoNotAvailable,
+    
+    // Level deletion not successful
+    #[error("Level deletion not successful")]
+    LevelDeletionFailed,
+
+    // Level modification not succesful
+    #[error("Level modification not successful")]
+    LevelModificationFailed,
+    
+    // Level insertion not successful
+    #[error("Level insertion not successful")]
+    LevelInsertionFailed,
+}
+
+#[derive(Error, Debug)]
+pub enum OrderError {
+
+    // Order not found
+    #[error("Order not found")]
+    OrderNotFound,
+    
+    // Order info not available
+    #[error("Order info not available")]
+    OrderInfoNotAvailable,
+    
+    // Order deletion not successful
+    #[error("Order deletion not successful")]
+    OrderDeletionFailed,
+    
+    // Order modification not successful
+    #[error("Order modification not successful")]
+    OrderModificationFailed,
+    
+    // Order insertion not succesful
+    #[error("Order insertion not successful")]
+    OrderInsertionFailed,
+
+}
+
+#[derive(Error, Debug)]
+pub enum GeneratorError {
+    
+    // Generator not found
+    #[error("Generator not found")]
+    GeneratorNotFound,
+
+    // Value not supported
+    #[error("The provided value is not supported by the generator")]
+    GeneratorValueError,
+}
+

--- a/atelier/src/errors/mod.rs
+++ b/atelier/src/errors/mod.rs
@@ -1,0 +1,1 @@
+pub mod errors;


### PR DESCRIPTION

An inclussion of some elements for the initial strategy of Custom Error Types for the project, starting for the Orderbook struct impls. 

this PR closes #34 

after this one a project structure refactor will be needed given some necessary modifications in the lib.rs and other places.